### PR TITLE
Calibrate tilt controls and hide game-over overlay

### DIFF
--- a/game.js
+++ b/game.js
@@ -51,10 +51,12 @@ let gameOver = false;
 const hud = document.getElementById('hud');
 const gameOverScreen = document.getElementById('game-over');
 const gameOverContent = document.getElementById('game-over-content');
+gameOverScreen.style.display = 'none';
 
 // Movement control variables
 let upPressed = false, downPressed = false, leftPressed = false, rightPressed = false;
 let latestBeta = 0, latestGamma = 0;  // last device tilt angles
+let baselineBeta = null, baselineGamma = null;
 const tiltThreshold = 10;            // minimum tilt (degrees) to move
 const moveSpeed = 0.00005;           // movement step per frame (approx ~0.00005° per frame)
 
@@ -73,8 +75,14 @@ window.addEventListener('click', function enableOrientation() {
 window.addEventListener('deviceorientation', (e) => {
   // e.beta: front-back tilt (-180 to 180), e.gamma: left-right tilt (-90 to 90)
   if (e.beta !== null && e.gamma !== null) {
-    latestBeta = e.beta;
-    latestGamma = e.gamma;
+    // Calibrate on first reading
+    if (baselineBeta === null) {
+      baselineBeta = e.beta;
+      baselineGamma = e.gamma;
+    }
+    // Adjust so controls are relative to initial orientation
+    latestBeta = e.beta - baselineBeta;
+    latestGamma = e.gamma - baselineGamma;
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -40,10 +40,6 @@ html, body {
   justify-content: center;
   font-family: sans-serif;
 }
-/* Use flexbox to center game-over text */
-#game-over {
-  display: flex;
-}
 #game-over-content {
   max-width: 80%;
   font-size: 32px;


### PR DESCRIPTION
## Summary
- Remove duplicate `#game-over` style that forced the overlay visible
- Calibrate device orientation to initial position for responsive tilt controls
- Explicitly hide game-over screen at startup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892c653eb4883288bfa25be0806894b