### PR TITLE
Fix helicopter icon configuration

### DIFF
--- a/game.js
+++ b/game.js
@@ -10,8 +10,8 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 // Use a custom image for the helicopter instead of the default emoji
 const heliIcon = L.icon({
   iconUrl: 'IMG_3540.png',
-  // size of the icon (matches the previous 30×30 emoji size)
-  i      iconSize: [300, 300]
+  // helicopter icon sized to 100x100 pixels for consistent display
+  iconSize: [100, 100]
 });
 const pizzaIcon = L.divIcon({ html: "🍕", className: "pizza-icon", iconSize: [30, 30] });
 const houseIcon = L.divIcon({ html: "🏠", className: "house-icon", iconSize: [30, 30] });


### PR DESCRIPTION
## Summary
- remove stray character that broke helicopter icon configuration
- set helicopter icon to 100x100 pixels for consistent display

## Testing
- `node --check game.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_6892d72614608328a8063580c33a725e