### PR TITLE
fix: lock map zoom level and disable user zooming

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,16 @@
-// Initialize map centered on Santa Cruz, California
-const map = L.map('map', { keyboard: false }).setView([36.974, -122.030], 14);
+// Initialize map centered on Santa Cruz, California with fixed zoom and no user zooming/panning
+const fixedZoom = 18;
+const map = L.map('map', {
+  keyboard: false,
+  dragging: false,
+  touchZoom: false,
+  scrollWheelZoom: false,
+  doubleClickZoom: false,
+  boxZoom: false,
+  zoomControl: false,
+  minZoom: fixedZoom,
+  maxZoom: fixedZoom
+}).setView([36.974, -122.030], fixedZoom);
 // Add OpenStreetMap tiles
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 19,


### PR DESCRIPTION
## Summary
- lock map to a fixed zoom level focused on Santa Cruz
- disable map zoom/pan interactions so users can't pinch or scroll

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '.../package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6892dd21b4248328b6de6f656b9f0f1d