### PR TITLE
Reduce helicopter icon size

### DIFF
--- a/game.js
+++ b/game.js
@@ -21,8 +21,9 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 // Use a custom image for the helicopter instead of the default emoji
 const heliIcon = L.icon({
   iconUrl: 'IMG_3540.png',
-  // scaled helicopter icon for better fit
-  iconSize: [200, 200]
+  // smaller helicopter icon for better map fit
+  iconSize: [80, 80],
+  iconAnchor: [40, 40]
 });
 const pizzaIcon = L.divIcon({ html: "🍕", className: "pizza-icon", iconSize: [30, 30] });
 const houseIcon = L.divIcon({ html: "🏠", className: "house-icon", iconSize: [30, 30] });


### PR DESCRIPTION
## Summary
- Resize helicopter icon to 80x80 and center it for a better fit on the map

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/santa-cruz-pizza-delivery-game/package.json')
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6892e06045388328af331600b8505d2d