### PR TITLE
Scale icons and add tap radius

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,8 +53,17 @@ html, body {
   background: none;
   border: none;
   text-align: center;
-  line-height: 30px;   /* center the emoji vertically in its 30px container */
-  font-size: 24px;     /* emoji size (adjust to fit icon size) */
+  line-height: 90px;   /* center the emoji vertically in its 90px container */
+  font-size: 72px;     /* emoji size (adjust to fit icon size) */
+}
+
+/* Small pizza icons used for the cargo tail */
+.tail-pizza-icon {
+  background: none;
+  border: none;
+  text-align: center;
+  line-height: 30px;
+  font-size: 24px;
 }
 
 /* Intro screen */


### PR DESCRIPTION
## Summary
- Spawn player near pizzeria and enlarge helicopter icon
- Enlarge pizzeria and house emojis and add 10px tap radius for pick-up and delivery
- Keep cargo pizzas small while supporting larger icons in styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892e7f703748328b411cf8b0f8c54e7