### PR TITLE
Add coin tip system and follow-up phone calls

### DIFF
--- a/style.css
+++ b/style.css
@@ -230,11 +230,12 @@ body {
   }
 }
 
-/* Increase the size of map icons (pizza, house, battery, turtle) */
+/* Increase the size of map icons (pizza, house, battery, turtle, coin) */
 .pizza-icon,
 .house-icon,
 .battery-icon,
-.turtle-icon {
+.turtle-icon,
+.coin-icon {
   /* Large font to fill the div container for the emoji icons */
   /* Slightly reduce font-size after enlarging icons (approx. 30% smaller) */
   font-size: 140px;


### PR DESCRIPTION
## Summary
- Spawn coin pickups near houses and track tips
- Award bonus tips for quick deliveries and display tip total on HUD
- Increase battery/turtle spawns and add reminder phone calls if a delivery lingers

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b791bd5c48328880e071123abe32e