### PR TITLE
Improve mobile layout and audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Santa Cruz Pizza Delivery Game</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover" />
   <!-- Main stylesheet for retro styles -->
   <link rel="stylesheet" href="style.css" />
   <!-- Leaflet CSS & JS for the game map -->
@@ -52,6 +52,7 @@
   <img id="phone-icon" src="images/phone.png" alt="Ringing phone icon" />
   <div id="msg-log" aria-live="polite"></div>
   <audio id="ring-audio" src="sounds/phone-ring.mp3" preload="auto" loop playsinline></audio>
+  <button id="sound-toggle" title="Enable sound">🔊</button>
 
   <!-- Game Over Screen (hidden until the game ends) -->
   <div id="game-over">

--- a/style.css
+++ b/style.css
@@ -11,6 +11,14 @@ body {
   overflow: hidden;
 }
 
+:root{
+  --nav-h: 0px;
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+}
+
 /* Intro screen overlay (covers the whole viewport) */
 #intro {
   position: absolute;
@@ -87,24 +95,25 @@ body {
 }
 
 /* Heads-up display (HUD) for deliveries and timers */
-#hud {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  font-family: "Hack", monospace;
-  font-size: 18px;
+#hud{
+  position:absolute;
+  top: calc(var(--safe-top) + var(--nav-h) + 10px);
+  left: calc(var(--safe-left) + 10px);
+  font-family:"Hack",monospace;
+  font-size: clamp(14px, 3.2vw, 18px);
   line-height: 1.3;
-  color: #fff;
-  background: rgba(0, 0, 0, 0.8);
-  padding: 6px 10px;
-  border: 2px solid #fff;
-  display: block;            /* was none */
-  z-index: 2000;
-  box-shadow: 0 2px 10px rgba(0,0,0,.5);
+  color:#fff;
+  background: rgba(0,0,0,.85);
+  padding:6px 10px;
+  border:2px solid #fff;
+  display:block;
+  z-index:2100;
+  box-shadow:0 2px 10px rgba(0,0,0,.5);
+  max-width: min(46vw, 360px);
 }
 
 /* compass and directional arrows */
-#compass{ position:absolute; bottom:10px; left:10px; z-index:2000; }
+#compass{ position:absolute; bottom: calc(var(--safe-bottom) + 10px); left: calc(var(--safe-left) + 10px); z-index:2000; }
 #pizza-compass{
   display:flex; align-items:center; gap:8px;
   background:rgba(0,0,0,.75); padding:6px 8px; border:1px solid rgba(255,255,255,.6);
@@ -117,16 +126,7 @@ body {
 #house-arrow{ display:none; }
 
 /* Phone icon (rings with pulse animation) */
-#phone-icon {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 56px;               /* a bit larger */
-  image-rendering: pixelated;
-  cursor: pointer;
-  display: none;
-  z-index: 2000;
-}
+#phone-icon{ position:absolute; top: calc(var(--safe-top) + 10px); right: calc(var(--safe-right) + 10px); width:56px; display:none; z-index:2000; image-rendering:pixelated; cursor:pointer; }
 #phone-icon.ringing {
   animation: phonePulse 1s infinite;
 }
@@ -137,22 +137,22 @@ body {
 }
 
 /* Phone message popup */
-#phone-message {
-  position: absolute;
-  top: 70px;
-  right: 10px;
-  font-family: "Hack", monospace;
-  font-size: 18px;
-  color: #fff;
-  background: rgba(0, 0, 0, 0.85);
-  padding: 8px 10px;
-  border: 2px solid #ffeb3b;
-  max-width: 80%;
+#phone-message{
+  position:absolute;
+  top: calc(var(--safe-top) + var(--nav-h) + 10px);
+  right: calc(var(--safe-right) + 10px);
+  font-family:"Hack",monospace;
+  font-size: clamp(14px, 3.2vw, 18px);
+  color:#fff;
+  background: rgba(0,0,0,.9);
+  padding:8px 10px;
+  border:2px solid #ffeb3b;
+  max-width: min(46vw, 360px);
   white-space: normal;
   overflow-wrap: break-word;
-  display: none;
-  z-index: 2000;
-  box-shadow: 0 2px 12px rgba(0,0,0,.6);
+  display:none;
+  z-index:2150;
+  box-shadow:0 2px 12px rgba(0,0,0,.6);
 }
 #phone-message.slide-in {
   animation: slideIn .25s ease-out;
@@ -164,11 +164,29 @@ body {
 
 /* navigation banner */
 #nav-banner{
-  position:absolute; top:10px; left:50%; transform:translateX(-50%);
-  display:none; align-items:center; gap:8px;
-  font-family:"Hack",monospace; font-size:20px; color:#111;
-  background:#ffeb3b; border:2px solid #111; padding:6px 12px; border-radius:6px;
-  z-index:2100; box-shadow:0 2px 10px rgba(0,0,0,.35);
+  position:absolute;
+  top: calc(var(--safe-top) + 6px);
+  left:50%;
+  transform:translateX(-50%);
+  display:none;
+  align-items:center;
+  gap:8px;
+  font-family:"Hack",monospace;
+  font-size: clamp(14px, 3.6vw, 20px);
+  color:#111;
+  background:#ffeb3b;
+  border:2px solid #111;
+  padding:6px 12px;
+  border-radius:6px;
+  z-index:2200;
+  box-shadow:0 2px 10px rgba(0,0,0,.35);
+  max-width: calc(100vw - 16px);
+}
+#nav-text{
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: calc(100vw - 88px); /* keeps arrow visible */
 }
 #nav-arrow{ width:34px; height:24px; flex-shrink:0; transform-origin:50% 50%; }
 
@@ -191,22 +209,28 @@ body {
 }
 
 /* Message log for last three messages */
-#msg-log {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  width: min(360px, 80vw);
-  font-family: "Hack", monospace;
-  z-index: 2000;
+#msg-log{
+  position:absolute;
+  bottom: calc(var(--safe-bottom) + 10px);
+  right: calc(var(--safe-right) + 10px);
+  width: min(92vw, 390px);
+  z-index:2050;
+  pointer-events:none;
 }
-#msg-log .msg {
-  background: rgba(0,0,0,.75);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,.6);
-  padding: 6px 8px;
-  margin-top: 6px;
-  font-size: 14px;
-  box-shadow: 0 2px 8px rgba(0,0,0,.5);
+#msg-log .msg{
+  background: rgba(0,0,0,.78);
+  color:#fff;
+  border:1px solid rgba(255,255,255,.6);
+  padding:6px 8px;
+  margin-top:8px;
+  font-size:14px;
+  box-shadow:0 2px 8px rgba(0,0,0,.5);
+  border-radius:8px;
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+  pointer-events:auto;
 }
 
 /* Pulsing target ring at active house */
@@ -244,11 +268,25 @@ body {
   max-width: 80%;
 }
 
-/* Responsive adjustments for mobile (phone message text) */
-@media (max-width: 480px) {
-  #phone-message {
-    font-size: 14px;
-  }
+/* sound toggle */
+#sound-toggle{
+  position:absolute;
+  bottom: calc(var(--safe-bottom) + 10px);
+  right: calc(var(--safe-right) + 10px);
+  z-index:2300;
+  font-size:16px;
+  padding:6px 10px;
+  border-radius:6px;
+  border:1px solid #111;
+  background:#ffeb3b;
+  color:#111;
+}
+
+/* mobile specific tweaks */
+@media (max-width: 640px){
+  #hud{ max-width: 44vw; }
+  #phone-message{ max-width: 44vw; }
+  #msg-log{ width: min(86vw, 360px); }
 }
 
 /* Increase the size of map icons (pizza, house, battery, turtle, coin) */


### PR DESCRIPTION
## Summary
- Add viewport-fit meta tag and sound toggle for mobile compatibility
- Anchor HUD, nav banner, phone messages and logs to safe-area insets
- Implement audio unlock with WebAudio beep fallback for ring tone

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bb36486b883288512925280e29c04