### PR TITLE
Add boss game-over sequence with restart

### DIFF
--- a/game.js
+++ b/game.js
@@ -553,11 +553,41 @@ function endGame(win) {
   [...batteryMarkers, ...turtleMarkers, ...coinMarkers].forEach(m => m && m.remove());
   activeOrders.forEach(o => o.house.remove());
   tailMarkers.forEach(m => m.remove());
-  // Show game over message
-  const msg = win
-    ? `Delivered all ${orders.length} orders. Great job.`
-    : `Time up. You delivered ${deliveredCount} of ${orders.length}.`;
-  gameOverContent.innerHTML = msg;
+  // Show game over message and optional boss sequence
+  if (win) {
+    gameOverContent.innerHTML = `Delivered all ${orders.length} orders. Great job.`;
+  } else {
+    gameOverContent.innerHTML = `
+      <div id="game-over-inner">
+        <img class="boss-img" src="images/boss.png" alt="Boss" />
+        <div id="game-over-text"></div>
+      </div>
+      <button id="play-again-btn" class="pulse">Play again</button>
+    `;
+    const sentences = [
+      "Damnit Mark, we didn't meet our quota.",
+      "Our stock is crashing!",
+      "You're Fired!"
+    ];
+    const textEl = document.getElementById('game-over-text');
+    let idx = 0;
+    function showNext() {
+      if (idx < sentences.length) {
+        textEl.innerHTML = '';
+        const p = document.createElement('p');
+        p.textContent = sentences[idx++];
+        textEl.appendChild(p);
+      } else {
+        clearInterval(interval);
+      }
+    }
+    showNext();
+    const interval = setInterval(showNext, 2500);
+    const playAgainBtn = document.getElementById('play-again-btn');
+    if (playAgainBtn) {
+      playAgainBtn.addEventListener('click', () => location.reload());
+    }
+  }
   gameOverScreen.style.display = 'flex';
   // Stop game background music
   try {
@@ -568,6 +598,18 @@ function endGame(win) {
     }
   } catch (e) {
     // Ignore errors if audio element isn't available
+  }
+  // Restart intro music on failure
+  if (!win) {
+    try {
+      const introAudioElem = document.getElementById('intro-audio');
+      if (introAudioElem) {
+        introAudioElem.currentTime = 0;
+        introAudioElem.play().catch(() => {});
+      }
+    } catch (e) {
+      // ignore audio errors
+    }
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -268,6 +268,41 @@ body {
   max-width: 80%;
 }
 
+/* Boss image and text layout for game over screen */
+#game-over-inner {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 20px;
+}
+#game-over-inner .boss-img {
+  width: 200px;
+  image-rendering: pixelated;
+  margin-right: 20px;
+}
+#game-over-text {
+  flex: 1;
+  font-size: 18px;
+  line-height: 1.4;
+  border-left: 2px solid #fff;
+  padding-left: 20px;
+  max-height: 35vh;
+  overflow-y: auto;
+}
+
+/* Play again button */
+#play-again-btn {
+  margin-top: 20px;
+  padding: 12px 28px;
+  font-size: 32px;
+  font-family: "Hack", monospace;
+  color: #fff;
+  background: #ff0000;
+  border: 2px solid #fff;
+  cursor: pointer;
+  animation: pulse 2s infinite;
+}
+
 /* sound toggle */
 #sound-toggle{
   position:absolute;


### PR DESCRIPTION
## Summary
- Display boss portrait and sequential firing messages when the player fails.
- Style game over overlay with boss image and add a pulsing **Play again** button.
- Resume intro music after a loss and offer quick restart.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689bbb1567f883288fc721f0e65e83e2