### PR TITLE
Add destination compass bar

### DIFF
--- a/game.js
+++ b/game.js
@@ -112,6 +112,9 @@ const compassEl   = document.getElementById('compass');
 const pizzaCompass= document.getElementById('pizza-compass');
 const pizzaArrow  = document.getElementById('pizza-arrow');
 const pizzaLabel  = document.getElementById('pizza-label');
+const destCompass = document.getElementById('dest-compass');
+const destArrow   = document.getElementById('dest-arrow');
+const destLabel   = document.getElementById('dest-label');
 const arrowTip    = document.getElementById('arrow-tip');
 const ringAudio   = document.getElementById('ring-audio');
 const soundToggle = document.getElementById('sound-toggle');
@@ -124,13 +127,13 @@ if (tutorialMsg) tutorialMsg.style.display = 'block';
 // Ensure HUD visible when game starts
 window.addEventListener('load', () => { hud.style.display = 'block'; });
 
-// recompute dock height so msg log never overlaps the compass
+// dock height drives message log offset
 function updateDockHeight(){
-  const h = pizzaCompass ? pizzaCompass.offsetHeight : 0;
+  const h = compassEl ? compassEl.offsetHeight : 0;
   document.documentElement.style.setProperty('--dock-h', `${h + 10}px`);
 }
-window.addEventListener('resize', updateDockHeight);
 window.addEventListener('load', updateDockHeight);
+window.addEventListener('resize', updateDockHeight);
 
 // tip bubble helpers
 let arrowTipTimer = null;
@@ -232,11 +235,23 @@ function updateNav(){
   const heli = L.latLng(heliLatLng);
   const shop = L.latLng(pizzaLatLng[0], pizzaLatLng[1]);
 
+  // pizzeria arrow and label
   const toShop = bearingFromTo(heli, shop);
-  pizzaArrow.style.transform = `rotate(${toShop - 90}deg)`;
+  pizzaArrow.style.transform = `rotate(${toShop - 90}deg)`;     // SVG points East
   pizzaLabel.textContent = `Pizzeria • ${formatDistance(heli.distanceTo(shop))}`;
 
-  // destination banner handled elsewhere
+  // destination bar
+  const active = activeOrders[0];
+  if (active && active.house){
+    const goal = active.house.getLatLng();
+    const toHouse = bearingFromTo(heli, goal);
+    destArrow.style.transform = `rotate(${toHouse - 90}deg)`;
+    destLabel.textContent = `${orders[active.idx].address} • ${formatDistance(heli.distanceTo(goal))}`;
+    destCompass.hidden = false;
+  } else {
+    destCompass.hidden = true;
+  }
+
   updateDockHeight();
 }
 setInterval(updateNav, 250);

--- a/index.html
+++ b/index.html
@@ -39,13 +39,22 @@
   </div>
 
   <div id="compass">
-    <div id="pizza-compass">
+    <div id="pizza-compass" class="compass-card">
       <svg id="pizza-arrow" viewBox="0 0 100 24" aria-hidden="true">
         <path d="M4 12 H70" stroke="#7CFC00" stroke-width="6" stroke-linecap="round"/>
         <path d="M60 4 L98 12 L60 20 Z" fill="#7CFC00"/>
       </svg>
       <span id="pizza-label">Pizzeria</span>
     </div>
+
+    <div id="dest-compass" class="compass-card" hidden>
+      <svg id="dest-arrow" viewBox="0 0 100 24" aria-hidden="true">
+        <path d="M4 12 H70" stroke="#ff5252" stroke-width="6" stroke-linecap="round"/>
+        <path d="M60 4 L98 12 L60 20 Z" fill="#ff5252"/>
+      </svg>
+      <span id="dest-label">Destination</span>
+    </div>
+
     <div id="arrow-tip" role="status" aria-live="polite"></div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -113,25 +113,39 @@ body {
   max-width: min(46vw, 360px);
 }
 
-/* pizza compass stays bottom left */
+/* dock both cards bottom-left, same size, row layout */
 #compass{
-  position: absolute;
-  left:  calc(var(--safe-left) + 10px);
-  bottom: calc(var(--safe-bottom) + 10px);
-  z-index: 2000;
+  position:absolute;
+  left: calc(var(--safe-left, 0px) + 10px);
+  bottom: calc(var(--safe-bottom, 0px) + 10px);
+  z-index:2000;
+  display:flex;
+  gap:10px;
+  align-items:flex-end;
 }
-#pizza-compass{
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: rgba(0,0,0,.78);
-  padding: 6px 8px;
+
+.compass-card{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  background: rgba(0,0,0,.82);
+  padding: 8px 10px;
   border: 1px solid rgba(255,255,255,.6);
-  border-radius: 8px;
+  border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0,0,0,.5);
+  height: 44px;                 /* same height for both bars */
 }
-#pizza-arrow{ width: 34px; height: 24px; transform-origin: 50% 50%; filter: drop-shadow(0 0 4px rgba(0,0,0,.6)); }
-#pizza-label{ color:#fff; font-family:"Hack",monospace; font-size:14px; }
+
+#pizza-arrow, #dest-arrow{
+  width:34px; height:24px;
+  transform-origin:50% 50%;
+  filter: drop-shadow(0 0 4px rgba(0,0,0,.6));
+}
+#pizza-label, #dest-label{
+  color:#fff; font-family:"Hack", monospace; font-size:14px;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+  max-width: min(44vw, 220px);
+}
 
 /* hide old house triangle if still present */
 #house-arrow{ display:none; }
@@ -221,15 +235,14 @@ body {
 
 /* Message log for last three messages */
 #msg-log{
-  position: absolute;
-  right: calc(var(--safe-right) + 10px);
-  bottom: calc(var(--safe-bottom) + 10px + var(--dock-h));
+  position:absolute;
+  right: calc(var(--safe-right, 0px) + 10px);
+  bottom: calc(var(--safe-bottom, 0px) + 10px + var(--dock-h, 60px));
   width: min(92vw, 390px);
-  z-index: 2050;
-  pointer-events: none;
+  z-index:2050; pointer-events:none;
 }
 #msg-log .msg{
-  pointer-events: auto;
+  pointer-events:auto;
   background: rgba(0,0,0,.85);
   color:#fff;
   border:1px solid rgba(255,255,255,.6);
@@ -271,6 +284,9 @@ body {
   border-right: 8px solid transparent;
   border-top: 10px solid #ffeb3b;        /* small pointer */
 }
+
+/* hide any old top banner if still present */
+#nav-banner{ display:none !important; }
 
 /* keep Leaflet attribution clear of overlays */
 .leaflet-control-attribution{


### PR DESCRIPTION
## Summary
- Place destination compass bar alongside the pizzeria compass for navigation
- Style both compass bars as a dock, updating message log offset and hiding old nav banner
- Update navigation logic to rotate destination arrow and show order distance

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689bcd7a03ac83288bf7b1f3b0657c94