### PR TITLE
Style dock compass rows evenly

### DIFF
--- a/game.js
+++ b/game.js
@@ -108,7 +108,6 @@ const navBanner   = document.getElementById('nav-banner');
 const navText     = document.getElementById('nav-text');
 const navArrow    = document.getElementById('nav-arrow');
 const msgLog      = document.getElementById('msg-log');
-const compassEl   = document.getElementById('compass');
 const pizzaCompass= document.getElementById('pizza-compass');
 const pizzaArrow  = document.getElementById('pizza-arrow');
 const pizzaLabel  = document.getElementById('pizza-label');
@@ -129,11 +128,14 @@ window.addEventListener('load', () => { hud.style.display = 'block'; });
 
 // dock height drives message log offset
 function updateDockHeight(){
-  const h = compassEl ? compassEl.offsetHeight : 0;
+  const dock = document.getElementById('compass');
+  const h = dock ? dock.offsetHeight : 0;
   document.documentElement.style.setProperty('--dock-h', `${h + 10}px`);
 }
 window.addEventListener('load', updateDockHeight);
 window.addEventListener('resize', updateDockHeight);
+setInterval(updateDockHeight, 500);
+
 
 // tip bubble helpers
 let arrowTipTimer = null;

--- a/style.css
+++ b/style.css
@@ -113,38 +113,53 @@ body {
   max-width: min(46vw, 360px);
 }
 
-/* dock both cards bottom-left, same size, row layout */
+/* Bottom dock: two bars on one row */
 #compass{
   position:absolute;
-  left: calc(var(--safe-left, 0px) + 10px);
-  bottom: calc(var(--safe-bottom, 0px) + 10px);
+  left:  calc(env(safe-area-inset-left, 0px) + 10px);
+  right: calc(env(safe-area-inset-right, 0px) + 10px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
   z-index:2000;
   display:flex;
-  gap:10px;
-  align-items:flex-end;
+  flex-direction:row;
+  align-items:stretch;
+  gap:8px;
+  flex-wrap:nowrap;              /* never stack */
 }
 
+/* Cards: equal width, compact height */
 .compass-card{
+  flex:1 1 0;                    /* split row evenly */
+  min-width:0;                   /* allow ellipsis */
   display:flex;
   align-items:center;
-  gap:8px;
+  gap:6px;
   background: rgba(0,0,0,.82);
-  padding: 8px 10px;
-  border: 1px solid rgba(255,255,255,.6);
-  border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0,0,0,.5);
-  height: 44px;                 /* same height for both bars */
+  padding:6px 8px;
+  border:1px solid rgba(255,255,255,.55);
+  border-radius:10px;
+  height:36px;
+  box-shadow:0 2px 8px rgba(0,0,0,.5);
 }
 
+/* Arrow icons smaller */
 #pizza-arrow, #dest-arrow{
-  width:34px; height:24px;
+  width:24px;
+  height:18px;
   transform-origin:50% 50%;
   filter: drop-shadow(0 0 4px rgba(0,0,0,.6));
 }
+
+/* Labels shrink and ellipsize */
 #pizza-label, #dest-label{
-  color:#fff; font-family:"Hack", monospace; font-size:14px;
-  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
-  max-width: min(44vw, 220px);
+  flex:1 1 auto;
+  min-width:0;
+  color:#fff;
+  font-family:"Hack", monospace;
+  font-size: clamp(12px, 3.3vw, 14px);
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 /* hide old house triangle if still present */
@@ -236,10 +251,11 @@ body {
 /* Message log for last three messages */
 #msg-log{
   position:absolute;
-  right: calc(var(--safe-right, 0px) + 10px);
-  bottom: calc(var(--safe-bottom, 0px) + 10px + var(--dock-h, 60px));
+  right: calc(env(safe-area-inset-right, 0px) + 10px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 10px + var(--dock-h, 44px));
   width: min(92vw, 390px);
-  z-index:2050; pointer-events:none;
+  z-index:2050;
+  pointer-events:none;
 }
 #msg-log .msg{
   pointer-events:auto;
@@ -255,6 +271,13 @@ body {
   -webkit-line-clamp: 2;       /* clamp to two lines on phones */
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+/* Very small screens tighten further */
+@media (max-width: 430px){
+  .compass-card{ height:32px; padding:5px 7px; gap:5px; }
+  #pizza-arrow, #dest-arrow{ width:22px; height:16px; }
+  #pizza-label, #dest-label{ font-size: clamp(11px, 3.5vw, 13px); }
 }
 
 /* tip bubble above the pizza compass */


### PR DESCRIPTION
## Summary
- Redesign compass dock so pizza and destination cards share a single bottom row with equal widths.
- Lower message log based on dynamic dock height and add small-screen compass tweaks.
- Add periodic dock height updater to keep overlays clear.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd3d119bc83289aaadb9bc64e2137