### PR TITLE
Fix compass dock to stay side by side

### DIFF
--- a/game.js
+++ b/game.js
@@ -115,6 +115,7 @@ const destCompass = document.getElementById('dest-compass');
 const destArrow   = document.getElementById('dest-arrow');
 const destLabel   = document.getElementById('dest-label');
 const arrowTip    = document.getElementById('arrow-tip');
+const compassEl   = document.getElementById('compass');
 const ringAudio   = document.getElementById('ring-audio');
 const soundToggle = document.getElementById('sound-toggle');
 const gameOverScreen  = document.getElementById('game-over');
@@ -126,15 +127,20 @@ if (tutorialMsg) tutorialMsg.style.display = 'block';
 // Ensure HUD visible when game starts
 window.addEventListener('load', () => { hud.style.display = 'block'; });
 
-// dock height drives message log offset
+// game.js — keep dock height in sync so the log never overlaps
 function updateDockHeight(){
-  const dock = document.getElementById('compass');
-  const h = dock ? dock.offsetHeight : 0;
+  const h = compassEl ? compassEl.offsetHeight : 0;
   document.documentElement.style.setProperty('--dock-h', `${h + 10}px`);
 }
-window.addEventListener('load', updateDockHeight);
-window.addEventListener('resize', updateDockHeight);
-setInterval(updateDockHeight, 500);
+window.addEventListener('load',  updateDockHeight);
+window.addEventListener('resize',updateDockHeight);
+setInterval(updateDockHeight, 500); // cheap guard
+
+// also react when the destination bar is shown/hidden
+if (destCompass){
+  new MutationObserver(updateDockHeight)
+    .observe(destCompass, { attributes: true, attributeFilter: ['hidden', 'style', 'class'] });
+}
 
 
 // tip bubble helpers

--- a/style.css
+++ b/style.css
@@ -419,3 +419,62 @@ body {
   font-size: 140px;
   line-height: 1;
 }
+
+/* === Bottom dock: FORCE side-by-side, smaller, never stack === */
+#compass{
+  position: absolute;
+  left:  calc(env(safe-area-inset-left, 0px) + 10px);
+  right: calc(env(safe-area-inset-right, 0px) + 10px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 10px);
+  z-index: 2000;
+  display: grid !important;              /* override old rules */
+  grid-template-columns: 1fr 1fr;        /* two equal columns */
+  gap: 6px;
+  align-items: center;
+}
+
+.compass-card{
+  min-width: 0;                          /* allow shrink */
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 5px 8px;
+  background: rgba(0,0,0,.84);
+  border: 1px solid rgba(255,255,255,.55);
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.5);
+}
+
+#pizza-arrow, #dest-arrow{
+  width: 22px;
+  height: 16px;
+  transform-origin: 50% 50%;
+  filter: drop-shadow(0 0 4px rgba(0,0,0,.6));
+}
+
+#pizza-label, #dest-label{
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: "Hack", monospace;
+  font-size: clamp(11px, 3.2vw, 13px);
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* hide destination cleanly when no active order */
+#dest-compass[hidden]{ display: none !important; }
+
+/* message log must clear dock height */
+#msg-log{
+  position: absolute;
+  right: calc(env(safe-area-inset-right, 0px) + 10px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 10px + var(--dock-h, 44px));
+  width: min(92vw, 390px);
+  z-index: 2050;
+  pointer-events: none;
+}
+#msg-log .msg{ pointer-events: auto; }
+


### PR DESCRIPTION
## Summary
- Ensure compass and destination bars always appear side-by-side in a single bottom row with compact cards
- Keep dock height variable synced and adjust message log offset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bda71fc548328bc7b8b87dea901bf