### PR TITLE
Ensure pizza tips overlay and one-tap restock

### DIFF
--- a/style.css
+++ b/style.css
@@ -478,3 +478,10 @@ body {
 }
 #msg-log .msg{ pointer-events: auto; }
 
+/* When a guidance tip is visible, raise the whole dock above everything. */
+#compass.tip-active { z-index: 9999 !important; }
+/* Tip bubble itself sits on top of the dock and other overlays. */
+#arrow-tip { z-index: 10000 !important; pointer-events: none; }
+/* Keep the message log below the dock so it never covers the tip. */
+#msg-log { z-index: 8000 !important; }
+


### PR DESCRIPTION
## Summary
- Raise compass tip and message layers above other overlays for visibility.
- Add `MAX_PIZZAS` constant with helper to fully restock and show high-priority tips.
- Enable single-tap pizzeria refills and guidance when orders need more pizzas.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689be04235b08328b67a5fadce8579d7