### PR TITLE
Hide message log and enhance HUD

### DIFF
--- a/style.css
+++ b/style.css
@@ -97,21 +97,23 @@ body {
 
 /* Heads-up display (HUD) for deliveries and timers */
 #hud{
-  position:absolute;
-  top: calc(var(--safe-top) + var(--nav-h) + 10px);
-  left: calc(var(--safe-left) + 10px);
-  font-family:"Hack",monospace;
+  position: absolute;
+  top: calc(var(--safe-top, 0px) + 10px);
+  left: calc(var(--safe-left, 0px) + 10px);
+  font-family: "Hack", monospace;
   font-size: clamp(14px, 3.2vw, 18px);
-  line-height: 1.3;
-  color:#fff;
-  background: rgba(0,0,0,.85);
-  padding:6px 10px;
-  border:2px solid #fff;
-  display:block;
-  z-index:2100;
-  box-shadow:0 2px 10px rgba(0,0,0,.5);
-  max-width: min(46vw, 360px);
+  line-height: 1.35;
+  color: #fff;
+  background: rgba(0,0,0,.88);
+  padding: 8px 12px;
+  border: 2px solid #fff;
+  border-radius: 10px;
+  box-shadow: 0 4px 14px rgba(0,0,0,.5);
+  backdrop-filter: saturate(120%) blur(2px);
+  z-index: 2100;
+  max-width: min(54vw, 380px);
 }
+#hud strong{ font-weight:700; }
 
 /* Bottom dock: two bars on one row */
 #compass{
@@ -403,7 +405,6 @@ body {
 
 /* mobile specific tweaks */
 @media (max-width: 640px){
-  #hud{ max-width: 44vw; }
   #phone-message{ max-width: 44vw; }
   #msg-log{ width: min(86vw, 360px); }
 }
@@ -483,5 +484,5 @@ body {
 /* Tip bubble itself sits on top of the dock and other overlays. */
 #arrow-tip { z-index: 10000 !important; pointer-events: none; }
 /* Keep the message log below the dock so it never covers the tip. */
-#msg-log { z-index: 8000 !important; }
+#msg-log { display: none !important; }
 


### PR DESCRIPTION
## Summary
- Hide bottom message log and disable logMessage
- Make phone messages linger for at least 6 seconds
- Show pizzas needed in HUD with crisper styling

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689be49b3d788328bb103ec412ab8280